### PR TITLE
Remove four tests "switch.const_expr_in_label"

### DIFF
--- a/test-lists/slang-passing-tests.txt
+++ b/test-lists/slang-passing-tests.txt
@@ -6673,10 +6673,6 @@ dEQP-VK.glsl.switch.conditional_fall_through_static_fragment
 dEQP-VK.glsl.switch.conditional_fall_through_static_vertex
 dEQP-VK.glsl.switch.conditional_fall_through_uniform_fragment
 dEQP-VK.glsl.switch.conditional_fall_through_uniform_vertex
-dEQP-VK.glsl.switch.const_expr_in_label_dynamic_fragment
-dEQP-VK.glsl.switch.const_expr_in_label_dynamic_vertex
-dEQP-VK.glsl.switch.const_expr_in_label_uniform_fragment
-dEQP-VK.glsl.switch.const_expr_in_label_uniform_vertex
 dEQP-VK.glsl.switch.default_label_dynamic_fragment
 dEQP-VK.glsl.switch.default_label_dynamic_vertex
 dEQP-VK.glsl.switch.default_label_static_fragment


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/5364

Slang now requires more strict type matching for the switch case labels.
The given tests are no longer valid for Slang.