### PR TITLE
Avoid include slang private headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,13 +485,9 @@ add_subdirectory(external/slang EXCLUDE_FROM_ALL)
 
 target_include_directories(vkutil PRIVATE
     ${CMAKE_SOURCE_DIR}/external/slang/src/include
-    ${CMAKE_SOURCE_DIR}/external/slang/src/source
-    ${CMAKE_SOURCE_DIR}/external/slang/src/tools
 )
 target_include_directories(vkscutil PRIVATE
     ${CMAKE_SOURCE_DIR}/external/slang/src/include
-    ${CMAKE_SOURCE_DIR}/external/slang/src/source
-    ${CMAKE_SOURCE_DIR}/external/slang/src/tools
 )
 
 target_compile_definitions(vkutil PRIVATE ENABLE_SLANG_COMPILATION)

--- a/external/vulkancts/framework/vulkan/vkShaderToSpirV_slang.cpp
+++ b/external/vulkancts/framework/vulkan/vkShaderToSpirV_slang.cpp
@@ -37,9 +37,38 @@ inline NullStream SLANG_LOG;
 #include <slang.h>
 #include <slang-com-ptr.h>
 
-// Additional includes
-#include <core/slang-list.h>
-#include <slang-test/test-context.h>
+// Local definitions for types previously pulled from private Slang headers
+// These replace includes of <core/slang-list.h> and <slang-test/test-context.h>
+namespace Slang
+{
+    typedef intptr_t Index;
+
+    enum class FileAccess
+    {
+        None = 0,
+        Read = 1,
+        Write = 2,
+        ReadWrite = 3
+    };
+
+    enum class StdStreamType
+    {
+        ErrorOut,
+        Out,
+        In,
+        CountOf,
+    };
+
+    namespace Process
+    {
+        enum Flag
+        {
+            // Ignored on non-Windows platforms
+            AttachDebugger = 0x01,
+            DisableStdErrRedirection = 0x02
+        };
+    }
+}
 
 #ifndef SLANG_RETURN_FAIL_ON_FALSE
 #define SLANG_RETURN_FAIL_ON_FALSE(x) \


### PR DESCRIPTION
This PR updates the VK-GL-CTS Slang integration to only use public Slang API headers instead of private/internal headers.

## Problem

When building VK-GL-CTS with Slang, the build fails with an indirect include error:

```
VK-GL-CTS\external\slang\src\source\core\slang-hash.h(7,10): error C1083: Cannot open include file: 'ankerl/unordered_dense.h': No such file or directory
```

This happens because VK-GL-CTS includes private Slang headers (e.g., from `source/core/`), which in turn include internal dependencies like `ankerl/unordered_dense.h` that are not exposed to external consumers.

## Changes

- Removed includes of private Slang headers (e.g., headers from `source/` directories)
- Updated code to use only the public API exposed through official Slang headers
- Add the flags and enum defs borrowed from the private headers
