### PR TITLE
Fix DLL name: load slang-compiler.dll instead of slang.dll

### DIFF
--- a/external/vulkancts/framework/vulkan/vkShaderToSpirV_slang.cpp
+++ b/external/vulkancts/framework/vulkan/vkShaderToSpirV_slang.cpp
@@ -555,10 +555,10 @@ public:
                     return SLANG_FAIL;
                 }
             }
-            handle = LoadLibraryA("slang.dll");
+            handle = LoadLibraryA("slang-compiler.dll");
             if (NULL == handle)
             {
-                SLANG_LOG << "failed to load slang.dll" << std::endl;
+                SLANG_LOG << "failed to load slang-compiler.dll" << std::endl;
                 return SLANG_FAIL;
             }
         }
@@ -1237,10 +1237,10 @@ public:
                 SLANG_LOG << "failed to set slang dll PATH" << std::endl;
                 return SLANG_FAIL;
             }
-            HMODULE handle = LoadLibraryA("slang.dll");
+            HMODULE handle = LoadLibraryA("slang-compiler.dll");
             if (NULL == handle)
             {
-                SLANG_LOG << "failed to load slang.dll" << std::endl;
+                SLANG_LOG << "failed to load slang-compiler.dll" << std::endl;
                 return SLANG_FAIL;
             }
 


### PR DESCRIPTION
## Summary

`vkShaderToSpirV_slang.cpp` has two `LoadLibraryA("slang.dll")` call sites (lines 558 and 1240). Slang renamed its main DLL from `slang.dll` to `slang-compiler.dll` and the nightly CI copies `slang-compiler.dll` into the CTS directory — so CTS fails to load it on every nightly run.

Change both call sites (and their matching error log strings) to use `slang-compiler.dll`.

Fixes shader-slang/slang#9352

## Notes on release process

The previous release (0.0.8) was kept as a pre-release specifically because of the naming transition — the nightly was still referencing 0.0.7 to avoid picking it up. Once this is merged and a 0.0.9 release is built, the nightly workflow in shader-slang/slang will need updating to reference 0.0.9.